### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tools/codegen/amalgamate.py
+++ b/tools/codegen/amalgamate.py
@@ -60,7 +60,7 @@ def main(argc, argv):
         template_data = fh.read()
 
     for base, _, filenames in os.walk(os.path.join(directory,
-            "tables_%s" % (name))):
+            "tables_{0!s}".format((name)))):
         for filename in filenames:
             if filename == name:
                 continue
@@ -70,7 +70,7 @@ def main(argc, argv):
 
     amalgamation = jinja2.Template(template_data).render(
         tables=tables)
-    output = os.path.join(directory, "%s_amalgamation.cpp" % name)
+    output = os.path.join(directory, "{0!s}_amalgamation.cpp".format(name))
     try:
         os.makedirs(os.path.dirname(output))
     except:

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -75,14 +75,14 @@ class Encoder(json.JSONEncoder):
         if isinstance(o, NoIndent):
             key = uuid.uuid4().hex
             self._replacement_map[key] = json.dumps(o.value, **self.kwargs)
-            return "@@%s@@" % (key,)
+            return "@@{0!s}@@".format(key)
         else:
             return super(Encoder, self).default(o)
 
     def encode(self, o):
         result = super(Encoder, self).encode(o)
         for k, v in self._replacement_map.iteritems():
-            result = result.replace('"@@%s@@"' % (k,), v)
+            result = result.replace('"@@{0!s}@@"'.format(k), v)
         return result
 
 
@@ -128,10 +128,10 @@ def gen_diff(api_old_path, api_new_path):
     new_tables = {}
     for category in api_new["tables"]:
         for table in category["tables"]:
-            new_tables["%s:%s" % (category["name"], table["name"])] = table
+            new_tables["{0!s}:{1!s}".format(category["name"], table["name"])] = table
     for category in api_old["tables"]:
         for table in category["tables"]:
-            old_tables["%s:%s" % (category["name"], table["name"])] = table
+            old_tables["{0!s}:{1!s}".format(category["name"], table["name"])] = table
 
     # Iterate backwards then forward to detect added/removed.
     tables_added = []
@@ -145,7 +145,7 @@ def gen_diff(api_old_path, api_new_path):
         for column in table["columns"]:
             old_columns = [c["name"] for c in old_tables[name]["columns"]]
             if column["name"] not in old_columns:
-                columns_added.append("%s:%s:%s:%s" % (category["name"],
+                columns_added.append("{0!s}:{1!s}:{2!s}:{3!s}".format(category["name"],
                     table["name"], column["name"], column["type"]))
 
     for name, table in old_tables.iteritems():
@@ -155,25 +155,25 @@ def gen_diff(api_old_path, api_new_path):
         for column in table["columns"]:
             new_columns = [c["name"] for c in new_tables[name]["columns"]]
             if column["name"] not in new_columns:
-                columns_removed.append("%s:%s:%s:%s" % (category["name"],
+                columns_removed.append("{0!s}:{1!s}:{2!s}:{3!s}".format(category["name"],
                     table["name"], column["name"], column["type"]))
 
     # Sort then pretty print (md) the changes.
     tables_added.sort()
     for name in tables_added:
-        print ("Added table `%s` to %s" % tuple(name.split(":")[::-1]))
+        print ("Added table `{0!s}` to {1!s}".format(*tuple(name.split(":")[::-1])))
     columns_added.sort()
     for name in columns_added:
         column = name.split(":")
-        print ("Added column `%s` (`%s`) to table `%s`" % (column[2], column[3],
+        print ("Added column `{0!s}` (`{1!s}`) to table `{2!s}`".format(column[2], column[3],
             column[1]))
     tables_removed.sort()
     for name in tables_removed:
-        print ("Removed table `%s` from %s" % tuple(name.split(":")[::-1]))
+        print ("Removed table `{0!s}` from {1!s}".format(*tuple(name.split(":")[::-1])))
     columns_removed.sort()
     for name in columns_removed:
         column = name.split(":")
-        print ("Removed column `%s` (`%s`) from table `%s`" % (column[2],
+        print ("Removed column `{0!s}` (`{1!s}`) from table `{2!s}`".format(column[2],
             column[3], column[1]))
 
 
@@ -200,7 +200,7 @@ def gen_api(tables_path, profile={}):
             with open(os.path.join(base, spec_file), "rU") as fh:
                 tree = ast.parse(fh.read())
                 table_spec = gen_spec(tree)
-                table_profile = profile.get("%s.%s" % (platform, name), {})
+                table_profile = profile.get("{0!s}.{1!s}".format(platform, name), {})
                 table_spec["profile"] = NoIndent(table_profile)
                 table_spec["blacklisted"] = is_blacklisted(table_spec["name"],
                                                            blacklist=blacklist)
@@ -243,19 +243,19 @@ def main(argc, argv):
         exit(0)
 
     if not os.path.exists(args.tables):
-        logging.error("Cannot find path: %s" % (args.tables))
+        logging.error("Cannot find path: {0!s}".format((args.tables)))
         exit(1)
 
     profile = {}
     if args.profile is not None:
         if not os.path.exists(args.profile):
-            logging.error("Cannot find path: %s" % (args.profile))
+            logging.error("Cannot find path: {0!s}".format((args.profile)))
             exit(1)
         with open(args.profile, "r") as fh:
             try:
                 profile = json.loads(fh.read())
             except Exception as e:
-                logging.error("Cannot parse profile data: %s" % (str(e)))
+                logging.error("Cannot parse profile data: {0!s}".format((str(e))))
                 exit(2)
 
     # Read in the optional list of blacklisted tables, then generate categories.

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -66,7 +66,7 @@ APPLICATION = "APPLICATION"
 def usage():
     """ print program usage """
     print(
-        "Usage: %s <spec.table> <file.cpp> [disable_blacklist]" % sys.argv[0])
+        "Usage: {0!s} <spec.table> <file.cpp> [disable_blacklist]".format(sys.argv[0]))
 
 
 def to_camel_case(snake_case):
@@ -76,7 +76,7 @@ def to_camel_case(snake_case):
 
 
 def lightred(msg):
-    return "\033[1;31m %s \033[0m" % str(msg)
+    return "\033[1;31m {0!s} \033[0m".format(str(msg))
 
 
 def is_blacklisted(table_name, path=None, blacklist=None):
@@ -116,7 +116,7 @@ def setup_templates(templates_path):
     if not os.path.exists(templates_path):
         templates_path = os.path.join(os.path.dirname(tables_path), "templates")
         if not os.path.exists(templates_path):
-            print ("Cannot read templates path: %s" % (templates_path))
+            print ("Cannot read templates path: {0!s}".format((templates_path)))
             exit(1)
     for template in os.listdir(templates_path):
         template_name = template.split(".", 1)[0]
@@ -180,7 +180,7 @@ class TableState(Singleton):
         )
 
         if self.table_name == "" or self.function == "":
-            print (lightred("Invalid table spec: %s" % (path)))
+            print (lightred("Invalid table spec: {0!s}".format((path))))
             exit(1)
 
         # Check for reserved column names
@@ -195,20 +195,20 @@ class TableState(Singleton):
         for i in range(1, len(path_bits)):
             dir_path = ""
             for j in range(i):
-                dir_path += "%s/" % path_bits[j]
+                dir_path += "{0!s}/".format(path_bits[j])
             if not os.path.exists(dir_path):
                 try:
                     os.mkdir(dir_path)
                 except:
                     # May encounter a race when using a make jobserver.
                     pass
-        logging.debug("generating %s" % path)
+        logging.debug("generating {0!s}".format(path))
         with open(path, "w+") as file_h:
             file_h.write(self.impl_content)
 
     def blacklist(self, path):
-        print (lightred("Blacklisting generated %s" % path))
-        logging.debug("blacklisting %s" % path)
+        print (lightred("Blacklisting generated {0!s}".format(path)))
+        logging.debug("blacklisting {0!s}".format(path))
         self.generate(path, template="blacklist")
 
 table = TableState()
@@ -244,7 +244,7 @@ class ForeignKey(object):
 def table_name(name):
     """define the virtual table name"""
     logging.debug("- table_name")
-    logging.debug("  - called with: %s" % name)
+    logging.debug("  - called with: {0!s}".format(name))
     table.table_name = name
     table.description = ""
     table.attributes = {}
@@ -259,9 +259,9 @@ def schema(schema_list):
     logging.debug("- schema")
     for it in schema_list:
         if isinstance(it, Column):
-            logging.debug("  - column: %s (%s)" % (it.name, it.type))
+            logging.debug("  - column: {0!s} ({1!s})".format(it.name, it.type))
         if isinstance(it, ForeignKey):
-            logging.debug("  - foreign_key: %s (%s)" % (it.column, it.table))
+            logging.debug("  - foreign_key: {0!s} ({1!s})".format(it.column, it.table))
     table.schema = schema_list
 
 
@@ -272,7 +272,7 @@ def description(text):
 def select_all(name=None):
     if name == None:
         name = table.table_name
-    return "select count(*) from %s;" % (name)
+    return "select count(*) from {0!s};".format((name))
 
 
 def examples(example_queries):
@@ -298,10 +298,10 @@ def implementation(impl_string):
     class_parts = function.split("::")[::-1]
     function = class_parts[0]
     class_name = class_parts[1] if len(class_parts) > 1 else ""
-    impl = "%s.cpp" % filename
-    logging.debug("  - impl => %s" % impl)
-    logging.debug("  - function => %s" % function)
-    logging.debug("  - class_name => %s" % class_name)
+    impl = "{0!s}.cpp".format(filename)
+    logging.debug("  - impl => {0!s}".format(impl))
+    logging.debug("  - function => {0!s}".format(function))
+    logging.debug("  - class_name => {0!s}".format(class_name))
     table.impl = impl
     table.function = function
     table.class_name = class_name
@@ -314,12 +314,12 @@ def implementation(impl_string):
             if isinstance(column, Column):
                 columns[column.name] = column.type
         if "time" not in columns:
-            print(lightred("Event subscriber: %s needs a 'time' column." % (
-                table.table_name)))
+            print(lightred("Event subscriber: {0!s} needs a 'time' column.".format((
+                table.table_name))))
             sys.exit(1)
         if columns["time"] is not BIGINT:
             print(lightred(
-                "Event subscriber: %s, 'time' column must be a %s type" % (
+                "Event subscriber: {0!s}, 'time' column must be a {1!s} type".format(
                     table.table_name, BIGINT)))
             sys.exit(1)
 

--- a/tools/codegen/gentargets.py
+++ b/tools/codegen/gentargets.py
@@ -88,13 +88,13 @@ if __name__ == "__main__":
             try:
                 json_data = json.loads(f.read())
             except ValueError:
-                logging.critical("Error: %s is not valid JSON" % args.input)
+                logging.critical("Error: {0!s} is not valid JSON".format(args.input))
 
             source_files = get_files_to_compile(json_data)
             print(TARGETS_PREAMBLE)
             for source_file in source_files:
-                print("    \"%s\"," % source_file)
+                print("    \"{0!s}\",".format(source_file))
             print(TARGETS_POSTSCRIPT % (args.version, args.sdk))
 
     except IOError:
-        logging.critical("Error: %s doesn't exist" % args.input)
+        logging.critical("Error: {0!s} doesn't exist".format(args.input))

--- a/tools/formatting/git-clang-format.py
+++ b/tools/formatting/git-clang-format.py
@@ -193,15 +193,15 @@ def interpret_args(args, dash_dash, default_commit):
     if len(args) == 0:
       commit = default_commit
     elif len(args) > 1:
-      die('at most one commit allowed; %d given' % len(args))
+      die('at most one commit allowed; {0:d} given'.format(len(args)))
     else:
       commit = args[0]
     object_type = get_object_type(commit)
     if object_type not in ('commit', 'tag'):
       if object_type is None:
-        die("'%s' is not a commit" % commit)
+        die("'{0!s}' is not a commit".format(commit))
       else:
-        die("'%s' is a %s, but a commit was expected" % (commit, object_type))
+        die("'{0!s}' is a {1!s}, but a commit was expected".format(commit, object_type))
     files = dash_dash[1:]
   elif args:
     if disambiguate_revision(args[0]):
@@ -226,8 +226,7 @@ def disambiguate_revision(value):
     return False
   if object_type in ('commit', 'tag'):
     return True
-  die('`%s` is a %s, but a commit or filename was expected' %
-      (value, object_type))
+  die('`{0!s}` is a {1!s}, but a commit or filename was expected'.format(value, object_type))
 
 
 def get_object_type(value):
@@ -326,7 +325,7 @@ def run_clang_format_and_save_to_tree(changed_lines, binary='clang-format',
       mode = oct(os.stat(filename).st_mode)
       blob_id = clang_format_to_blob(filename, line_ranges, binary=binary,
                                      style=style)
-      yield '%s %s\t%s' % (mode, blob_id, filename)
+      yield '{0!s} {1!s}\t{2!s}'.format(mode, blob_id, filename)
   return create_tree(index_info_generator(), '--index-info')
 
 
@@ -342,10 +341,10 @@ def create_tree(input_lines, mode):
   with temporary_index_file():
     p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
     for line in input_lines:
-      p.stdin.write('%s\0' % line)
+      p.stdin.write('{0!s}\0'.format(line))
     p.stdin.close()
     if p.wait() != 0:
-      die('`%s` failed' % ' '.join(cmd))
+      die('`{0!s}` failed'.format(' '.join(cmd)))
     tree_id = run('git', 'write-tree')
     return tree_id
 
@@ -359,14 +358,14 @@ def clang_format_to_blob(filename, line_ranges, binary='clang-format',
   if style:
     clang_format_cmd.extend(['-style='+style])
   clang_format_cmd.extend([
-      '-lines=%s:%s' % (start_line, start_line+line_count-1)
+      '-lines={0!s}:{1!s}'.format(start_line, start_line+line_count-1)
       for start_line, line_count in line_ranges])
   try:
     clang_format = subprocess.Popen(clang_format_cmd, stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE)
   except OSError as e:
     if e.errno == errno.ENOENT:
-      die('cannot find executable "%s"' % binary)
+      die('cannot find executable "{0!s}"'.format(binary))
     else:
       raise
   clang_format.stdin.close()
@@ -376,9 +375,9 @@ def clang_format_to_blob(filename, line_ranges, binary='clang-format',
   clang_format.stdout.close()
   stdout = hash_object.communicate()[0]
   if hash_object.returncode != 0:
-    die('`%s` failed' % ' '.join(hash_object_cmd))
+    die('`{0!s}` failed'.format(' '.join(hash_object_cmd)))
   if clang_format.wait() != 0:
-    die('`%s` failed' % ' '.join(clang_format_cmd))
+    die('`{0!s}` failed'.format(' '.join(clang_format_cmd)))
   return stdout.rstrip('\r\n')
 
 
@@ -456,20 +455,20 @@ def run(*args, **kwargs):
   verbose = kwargs.pop('verbose', True)
   strip = kwargs.pop('strip', True)
   for name in kwargs:
-    raise TypeError("run() got an unexpected keyword argument '%s'" % name)
+    raise TypeError("run() got an unexpected keyword argument '{0!s}'".format(name))
   p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                        stdin=subprocess.PIPE)
   stdout, stderr = p.communicate(input=stdin)
   if p.returncode == 0:
     if stderr:
       if verbose:
-        print >>sys.stderr, '`%s` printed to stderr:' % ' '.join(args)
+        print >>sys.stderr, '`{0!s}` printed to stderr:'.format(' '.join(args))
       print >>sys.stderr, stderr.rstrip()
     if strip:
       stdout = stdout.rstrip('\r\n')
     return stdout
   if verbose:
-    print >>sys.stderr, '`%s` returned %s' % (' '.join(args), p.returncode)
+    print >>sys.stderr, '`{0!s}` returned {1!s}'.format(' '.join(args), p.returncode)
   if stderr:
     print >>sys.stderr, stderr.rstrip()
   sys.exit(2)

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -54,8 +54,8 @@ def get_stats(p, interval=1):
 
 def check_leaks_linux(shell, query, count=1, supp_file=None):
     """Run valgrind using the shell and a query, parse leak reports."""
-    suppressions = "" if supp_file is None else "--suppressions=%s" % supp_file
-    cmd = "valgrind --tool=memcheck %s %s --iterations=%d --query=\"%s\"" % (
+    suppressions = "" if supp_file is None else "--suppressions={0!s}".format(supp_file)
+    cmd = "valgrind --tool=memcheck {0!s} {1!s} --iterations={2:d} --query=\"{3!s}\"".format(
         suppressions, shell, count, query)
     proc = subprocess.Popen(
         cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -84,7 +84,7 @@ def check_leaks_darwin(shell, query, count=1):
     while proc.poll() is None:
         # Continue to run leaks until the monitored shell exits.
         leaks = subprocess.Popen(
-            ["leaks", "%s" % proc.pid],
+            ["leaks", "{0!s}".format(proc.pid)],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         stdout, _ = leaks.communicate()
@@ -110,7 +110,7 @@ def check_leaks(shell, query, count=1, supp_file=None):
 def profile_leaks(shell, queries, count=1, rounds=1, supp_file=None):
     report = {}
     for name, query in queries.iteritems():
-        print ("Analyzing leaks in query: %s" % query)
+        print ("Analyzing leaks in query: {0!s}".format(query))
         # Apply count (optionally run the query several times).
         summary = check_leaks(shell, query, count, supp_file)
         display = []
@@ -126,8 +126,8 @@ def profile_leaks(shell, queries, count=1, rounds=1, supp_file=None):
                     report[name] = "WARNING"
             else:
                 report[name] = "SAFE"
-            display.append("%s: %s" % (key, output))
-        print ("  %s" % "; ".join(display))
+            display.append("{0!s}: {1!s}".format(key, output))
+        print ("  {0!s}".format("; ".join(display)))
     return report
 
 
@@ -183,14 +183,14 @@ def run_query(shell, query, timeout=0, count=1):
 def summary_line(name, result):
     if not args.n:
         for key, v in result.iteritems():
-            print ("%s" % (
-                RANGES["colors"][v[0]]("%s:%s" % (
-                    key[0].upper(), v[0]))),
+            print ("{0!s}".format((
+                RANGES["colors"][v[0]]("{0!s}:{1!s}".format(
+                    key[0].upper(), v[0])))),
                 end="")
         print (" ", end="")
-    print ("%s:" % name, end=" ")
+    print ("{0!s}:".format(name), end=" ")
     for key, v in result.iteritems():
-        print ("%s: %s" % (key, v[1]), end=" ")
+        print ("{0!s}: {1!s}".format(key, v[1]), end=" ")
     print ("")
 
 
@@ -225,12 +225,12 @@ def summary(results, display=False):
 def profile(shell, queries, timeout=0, count=1, rounds=1):
     report = {}
     for name, query in queries.iteritems():
-        print ("Profiling query: %s" % query)
+        print ("Profiling query: {0!s}".format(query))
         results = {}
         for i in range(rounds):
             result = run_query(shell, query, timeout=timeout, count=count)
             summary(
-                {"%s (%d/%d)" % (name, i + 1, rounds): result}, display=True)
+                {"{0!s} ({1:d}/{2:d})".format(name, i + 1, rounds): result}, display=True)
             # Store each result round to return an average.
             for k, v in result.iteritems():
                 results[k] = results.get(k, [])
@@ -240,7 +240,7 @@ def profile(shell, queries, timeout=0, count=1, rounds=1):
             average_results[k] = sum(results[k]) / len(results[k])
         report[name] = average_results
         if rounds > 1:
-            summary({"%s   avg" % name: report[name]}, display=True)
+            summary({"{0!s}   avg".format(name): report[name]}, display=True)
     return report
 
 def compare(profile1, profile2):
@@ -260,7 +260,7 @@ def regress_check(profile1, profile2):
             continue
         for measure in profile1[table]:
             if profile2[table][measure][0] > profile1[table][measure][0]:
-                print ("%s %s has regressed (%s->%s)!" % (table, measure,
+                print ("{0!s} {1!s} has regressed ({2!s}->{3!s})!".format(table, measure,
                     profile1[table][measure][0], profile2[table][measure][0]))
                 regressed = True
     if not regressed:
@@ -315,8 +315,8 @@ if __name__ == "__main__":
         help="Run the profile for N rounds and use the average."
     )
     group.add_argument(
-        "--shell", metavar="PATH", default="./build/%s/osquery/run" % (
-            utils.platform()),
+        "--shell", metavar="PATH", default="./build/{0!s}/osquery/run".format((
+            utils.platform())),
         help="Path to osquery run wrapper (./build/<sys>/osquery/run)."
     )
 
@@ -354,16 +354,16 @@ if __name__ == "__main__":
             profile1 = json.loads(fh.read())
 
     if not os.path.exists(args.shell):
-        print ("Cannot find --daemon: %s" % (args.shell))
+        print ("Cannot find --daemon: {0!s}".format((args.shell)))
         exit(1)
     if args.config is None and not os.path.exists(args.tables):
-        print ("Cannot find --tables: %s" % (args.tables))
+        print ("Cannot find --tables: {0!s}".format((args.tables)))
         exit(1)
 
     queries = {}
     if args.config is not None:
         if not os.path.exists(args.config):
-            print ("Cannot find --config: %s" % (args.config))
+            print ("Cannot find --config: {0!s}".format((args.config)))
             exit(1)
         queries = utils.queries_from_config(args.config)
     elif args.query is not None:
@@ -394,4 +394,4 @@ if __name__ == "__main__":
                 fh.write(json.dumps(results, indent=1))
             else:
                 fh.write(json.dumps(summary(results), indent=1))
-        print ("Wrote output summary: %s" % args.output)
+        print ("Wrote output summary: {0!s}".format(args.output))

--- a/tools/tests/stress.py
+++ b/tools/tests/stress.py
@@ -37,10 +37,10 @@ def stress(args):
         if proc.returncode is not 0:
             print (stdout)
             print (stderr)
-            print ("%s Test %d failed. (total %6.4fs)" % (
+            print ("{0!s} Test {1:d} failed. (total {2:6.4f}s)".format(
                 red("FAILED"), i + 1, sum(times)))
             return proc.returncode
-        print ("%s Tests passed (%d/%d) rounds. (average %6.4fs) " % (
+        print ("{0!s} Tests passed ({1:d}/{2:d}) rounds. (average {3:6.4f}s) ".format(
             green("PASSED"), i + 1, args["num"], sum(times) / len(times)))
     return 0
 

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -30,10 +30,10 @@ import pexpect
 try:
     from pexpect.replwrap import REPLWrapper
 except ImportError as e:
-    print("Could not import pexpect.replwrap: %s" % (str(e)))
-    print("  Need pexpect version 3.3, installed version: %s" % (
-        str(pexpect.__version__)))
-    print("  pexpect location: %s" % (str(pexpect.__file__)))
+    print("Could not import pexpect.replwrap: {0!s}".format((str(e))))
+    print("  Need pexpect version 3.3, installed version: {0!s}".format((
+        str(pexpect.__version__))))
+    print("  pexpect location: {0!s}".format((str(pexpect.__file__))))
     exit(1)
 
 try:
@@ -57,10 +57,10 @@ CONFIG_DIR = "/tmp/osquery-tests/"
 CONFIG_NAME = CONFIG_DIR + "tests"
 DEFAULT_CONFIG = {
     "options": {
-        "database_path": "%s.db" % CONFIG_NAME,
-        "pidfile": "%s.pid" % CONFIG_NAME,
-        "config_path": "%s.conf" % CONFIG_NAME,
-        "extensions_socket": "%s.em" % CONFIG_NAME,
+        "database_path": "{0!s}.db".format(CONFIG_NAME),
+        "pidfile": "{0!s}.pid".format(CONFIG_NAME),
+        "config_path": "{0!s}.conf".format(CONFIG_NAME),
+        "extensions_socket": "{0!s}.em".format(CONFIG_NAME),
         "extensions_interval": "1",
         "extensions_timeout": "0",
         "watchdog_level": "3",
@@ -100,7 +100,7 @@ class OsqueryWrapper(REPLWrapper):
         for option in args.keys():
             options[option] = args[option]
         options["database_path"] += str(random.randint(1000, 9999))
-        command = command + " " + " ".join(["--%s=%s" % (k, v) for
+        command = command + " " + " ".join(["--{0!s}={1!s}".format(k, v) for
             k, v in options.iteritems()])
         proc = pexpect.spawn(command, env=env)
         super(OsqueryWrapper, self).__init__(
@@ -123,7 +123,7 @@ class OsqueryWrapper(REPLWrapper):
 
         if len(result_lines) < 1:
             raise OsqueryUnknownException(
-                'Unexpected output:\n %s' % result_lines)
+                'Unexpected output:\n {0!s}'.format(result_lines))
         if result_lines[0].startswith(self.ERROR_PREFIX):
             raise OsqueryException(result_lines[0])
 
@@ -138,7 +138,7 @@ class OsqueryWrapper(REPLWrapper):
             return rows
         except:
             raise OsqueryUnknownException(
-                'Unexpected output:\n %s' % result_lines)
+                'Unexpected output:\n {0!s}'.format(result_lines))
 
 
 class ProcRunner(object):
@@ -171,7 +171,7 @@ class ProcRunner(object):
             pid = self.proc.pid
             self.started = True
         except Exception as e:
-            print (utils.red("Process start failed:") + " %s" % self.name)
+            print (utils.red("Process start failed:") + " {0!s}".format(self.name))
             print (str(e))
             sys.exit(1)
         try:
@@ -281,7 +281,7 @@ class ProcessGenerator(object):
         config["options"]["extensions_socket"] += str(random.randint(1000, 9999))
         for option in options.keys():
             config["options"][option] = options[option]
-        flags = ["--%s=%s" % (k, v) for k, v in config["options"].items()]
+        flags = ["--{0!s}={1!s}".format(k, v) for k, v in config["options"].items()]
         for option in options_only.keys():
             config["options"][option] = options_only[option]
         for key in overwrite:
@@ -305,10 +305,10 @@ class ProcessGenerator(object):
         extension = ProcRunner("extension",
             binary,
             [
-                "--socket=%s" % config["options"]["extensions_socket"],
+                "--socket={0!s}".format(config["options"]["extensions_socket"]),
                 "--verbose" if not silent else "",
-                "--timeout=%d" % timeout,
-                "--interval=%d" % 0,
+                "--timeout={0:d}".format(timeout),
+                "--interval={0:d}".format(0),
             ],
             silent=silent)
         self.generators.append(extension)
@@ -346,7 +346,7 @@ class EXClient:
             path = CONFIG["options"]["extensions_socket"]
         self.path = path
         if uuid:
-            self.path += ".%s" % str(uuid)
+            self.path += ".{0!s}".format(str(uuid))
         transport = TSocket.TSocket(unix_socket=self.path)
         transport = TTransport.TBufferedTransport(transport)
         self.protocol = TBinaryProtocol.TBinaryProtocol(transport)
@@ -439,7 +439,7 @@ class Tester(object):
         ARGS = parser.parse_args()
 
         if not os.path.exists(ARGS.build):
-            print ("Cannot find --build: %s" % ARGS.build)
+            print ("Cannot find --build: {0!s}".format(ARGS.build))
             print ("You must first run: make")
             exit(1)
 
@@ -472,7 +472,7 @@ def expect(functional, expected, interval=0.01, timeout=4):
             if len(result) == expected:
                 break
         except Exception as e:
-            print ("Expect exception (%s): %s not %s" % (
+            print ("Expect exception ({0!s}): {1!s} not {2!s}".format(
                 str(e), str(functional), expected))
             return None
         if delay >= timeout:
@@ -497,7 +497,7 @@ def assertPermissions():
     stat_info = os.stat('.')
     if stat_info.st_uid != os.getuid():
         print (utils.lightred("Will not load modules/extensions in tests."))
-        print (utils.lightred("Repository owner (%d) executer (%d) mismatch" % (
+        print (utils.lightred("Repository owner ({0:d}) executer ({1:d}) mismatch".format(
             stat_info.st_uid, os.getuid())))
         exit(1)
 
@@ -511,7 +511,7 @@ def loadThriftFromBuild(build_dir):
         from osquery import ExtensionManager, Extension
         EXClient.setUp(ExtensionManager, Extension)
     except ImportError as e:
-        print ("Cannot import osquery thrift API from %s" % (thrift_path))
-        print ("Exception: %s" % (str(e)))
+        print ("Cannot import osquery thrift API from {0!s}".format((thrift_path)))
+        print ("Exception: {0!s}".format((str(e))))
         print ("You must first run: make")
         exit(1)

--- a/tools/tests/test_example_queries.py
+++ b/tools/tests/test_example_queries.py
@@ -48,8 +48,8 @@ class ExampleQueryTests(test_base.ProcessGenerator, unittest.TestCase):
             self.assertEqual(result.status.code, 0)
             return result.response
         except Exception as e:
-            print("General exception executing query: %s" % (
-                utils.lightred(query)))
+            print("General exception executing query: {0!s}".format((
+                utils.lightred(query))))
             raise e
 
     def _execute_set(self, queries):
@@ -61,7 +61,7 @@ class ExampleQueryTests(test_base.ProcessGenerator, unittest.TestCase):
             if duration_ms > 2000:
                 # Query took longer than 2 seconds.
                 duration_ms = utils.lightred(duration_ms)
-            print("Query (%sms): %s, rows: %d" % (
+            print("Query ({0!s}ms): {1!s}, rows: {2:d}".format(
                 duration_ms, example, len(result)))
 
 

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -47,7 +47,7 @@ ENROLL_RESPONSE = {
 }
 
 def debug(response):
-    print("-- [DEBUG] %s" % str(response))
+    print("-- [DEBUG] {0!s}".format(str(response)))
 
 class RealSimpleHandler(BaseHTTPRequestHandler):
     def _set_headers(self):
@@ -56,20 +56,20 @@ class RealSimpleHandler(BaseHTTPRequestHandler):
         self.end_headers()
  
     def do_GET(self):
-        debug("RealSimpleHandler::get %s" % self.path)
+        debug("RealSimpleHandler::get {0!s}".format(self.path))
         self._set_headers()
         self._reply(TEST_RESPONSE)
  
     def do_HEAD(self):
-        debug("RealSimpleHandler::head %s" % self.path)
+        debug("RealSimpleHandler::head {0!s}".format(self.path))
         self._set_headers()
         
     def do_POST(self):
-        debug("RealSimpleHandler::post %s" % self.path)
+        debug("RealSimpleHandler::post {0!s}".format(self.path))
         self._set_headers()
         content_len = int(self.headers.getheader('content-length', 0))
         request = json.loads(self.rfile.read(content_len))
-        debug("Request: %s" % str(request))
+        debug("Request: {0!s}".format(str(request)))
 
         if self.path == '/enroll':
             self.enroll(request)
@@ -118,12 +118,11 @@ class RealSimpleHandler(BaseHTTPRequestHandler):
         self._reply({})
 
     def _reply(self, response):
-        debug("Replying: %s" % (str(response)))
+        debug("Replying: {0!s}".format((str(response))))
         self.wfile.write(json.dumps(response))
 
 def handler(signum, frame):
-    print("[DEBUG] Shutting down HTTP server via timeout (%d) seconds."
-        % (ARGS.timeout))
+    print("[DEBUG] Shutting down HTTP server via timeout ({0:d}) seconds.".format((ARGS.timeout)))
     sys.exit(0)
 
 if __name__ == '__main__':
@@ -185,7 +184,7 @@ if __name__ == '__main__':
             with open(ARGS.enroll_secret, "r") as fh:
                 ENROLL_SECRET = fh.read().strip()
         except IOError as e:
-            print("Cannot read --enroll_secret: %s" % str(e))
+            print("Cannot read --enroll_secret: {0!s}".format(str(e)))
             exit(1)
 
     if not ARGS.persist:
@@ -207,7 +206,7 @@ if __name__ == '__main__':
                 certfile=ARGS.cert,
                 keyfile=ARGS.key,
                 server_side=True)
-        debug("Starting TLS/HTTPS server on TCP port: %d" % ARGS.port)
+        debug("Starting TLS/HTTPS server on TCP port: {0:d}".format(ARGS.port))
     else:
-        debug("Starting HTTP server on TCP port: %d" % ARGS.port)
+        debug("Starting HTTP server on TCP port: {0:d}".format(ARGS.port))
     httpd.serve_forever()

--- a/tools/tests/test_modules.py
+++ b/tools/tests/test_modules.py
@@ -26,7 +26,7 @@ class ModuleTests(test_base.ProcessGenerator, unittest.TestCase):
         self.binary = os.path.join(test_base.ARGS.build, "osquery", "osqueryi")
         ext = "dylib" if sys.platform == "darwin" else "so"
         self.modules_loader = test_base.Autoloader(
-            [test_base.ARGS.build + "/osquery/libmodexample.%s" % ext])
+            [test_base.ARGS.build + "/osquery/libmodexample.{0!s}".format(ext)])
         self.osqueryi = test_base.OsqueryWrapper(self.binary,
             {"modules_autoload": self.modules_loader.path})
 

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -26,7 +26,7 @@ class OsqueryiTest(unittest.TestCase):
     def setUp(self):
         self.binary = os.path.join(test_base.ARGS.build, "osquery", "osqueryi")
         self.osqueryi = test_base.OsqueryWrapper(self.binary)
-        self.dbpath = "%s%s" % (
+        self.dbpath = "{0!s}{1!s}".format(
             test_base.CONFIG["options"]["database_path"],
             str(random.randint(1000, 9999)))
 
@@ -41,8 +41,8 @@ class OsqueryiTest(unittest.TestCase):
         proc = test_base.TimeoutRunner([
                 self.binary,
                 "--config_check",
-                "--database_path=%s" % (self.dbpath),
-                "--config_path=%s/test.config" % test_base.SCRIPT_DIR
+                "--database_path={0!s}".format((self.dbpath)),
+                "--config_path={0!s}/test.config".format(test_base.SCRIPT_DIR)
             ],
             SHELL_TIMEOUT)
         self.assertEqual(proc.stdout, "")
@@ -55,7 +55,7 @@ class OsqueryiTest(unittest.TestCase):
         proc = test_base.TimeoutRunner([
             self.binary,
                 "--config_check",
-                "--database_path=%s" % (self.dbpath),
+                "--database_path={0!s}".format((self.dbpath)),
                 "--config_path=/this/path/does/not/exist"
             ],
             SHELL_TIMEOUT)
@@ -68,8 +68,8 @@ class OsqueryiTest(unittest.TestCase):
         proc = test_base.TimeoutRunner([
                 self.binary,
                 "--config_check",
-                "--database_path=%s" % (self.dbpath),
-                "--config_path=%s/test.badconfig" % test_base.SCRIPT_DIR
+                "--database_path={0!s}".format((self.dbpath)),
+                "--config_path={0!s}/test.badconfig".format(test_base.SCRIPT_DIR)
             ],
             SHELL_TIMEOUT)
         self.assertEqual(proc.proc.poll(), 1)
@@ -79,7 +79,7 @@ class OsqueryiTest(unittest.TestCase):
         proc = test_base.TimeoutRunner([
                 self.binary,
                 "--config_check",
-                "--database_path=%s" % (self.dbpath),
+                "--database_path={0!s}".format((self.dbpath)),
                 "--config_plugin=does_not_exist"
             ],
             SHELL_TIMEOUT)

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -17,23 +17,23 @@ import os
 import sys
 
 def red(msg):
-    return "\033[41m\033[1;30m %s \033[0m" % str(msg)
+    return "\033[41m\033[1;30m {0!s} \033[0m".format(str(msg))
 
 
 def lightred(msg):
-    return "\033[1;31m%s\033[0m" % str(msg)
+    return "\033[1;31m{0!s}\033[0m".format(str(msg))
 
 
 def yellow(msg):
-    return "\033[43m\033[1;30m %s \033[0m" % str(msg)
+    return "\033[43m\033[1;30m {0!s} \033[0m".format(str(msg))
 
 
 def green(msg):
-    return "\033[42m\033[1;30m %s \033[0m" % str(msg)
+    return "\033[42m\033[1;30m {0!s} \033[0m".format(str(msg))
 
 
 def blue(msg):
-    return "\033[46m\033[1;30m %s \033[0m" % str(msg)
+    return "\033[46m\033[1;30m {0!s} \033[0m".format(str(msg))
 
 
 def read_config(path):
@@ -63,7 +63,7 @@ def queries_from_config(config_path):
         with open(config_path, "r") as fh:
             config = json.loads(fh.read())
     except Exception as e:
-        print ("Cannot open/parse config: %s" % str(e))
+        print ("Cannot open/parse config: {0!s}".format(str(e)))
         exit(1)
     queries = {}
     if "scheduledQueries" in config:
@@ -73,7 +73,7 @@ def queries_from_config(config_path):
         for name, details in config["schedule"].iteritems():
             queries[name] = details["query"]
     if len(queries) == 0:
-        print ("Could not find a schedule/queries in config: %s" % config_path)
+        print ("Could not find a schedule/queries in config: {0!s}".format(config_path))
         exit(0)
     return queries
 
@@ -93,12 +93,12 @@ def queries_from_tables(path, restrict):
             if spec_platform not in ["specs", platform]:
                 continue
             # Generate all tables to select from, with abandon.
-            tables.append("%s.%s" % (spec_platform, table_name))
+            tables.append("{0!s}.{1!s}".format(spec_platform, table_name))
 
     if len(restrict) > 0:
         tables = [t for t in tables if t.split(".")[1] in restrict_tables]
     queries = {}
     for table in tables:
-        queries[table] = "SELECT * FROM %s;" % table.split(".", 1)[1]
+        queries[table] = "SELECT * FROM {0!s};".format(table.split(".", 1)[1])
     return queries
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:osquery?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:osquery?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
